### PR TITLE
Add BIQU SKR, Update MKS SBASE, and Misc

### DIFF
--- a/src/LPC/Pins_LPC.h
+++ b/src/LPC/Pins_LPC.h
@@ -12,10 +12,6 @@ const size_t NumFirmwareUpdateModules = 0;
 #define UNUSED(x) (void)(x)
 #endif
 
-
-
-
-
 #define FIRMWARE_NAME "RepRapFirmware for LPC176[8/9] based Boards"
 
 
@@ -34,33 +30,23 @@ const size_t NumFirmwareUpdateModules = 0;
 #define HAS_VREF_MONITOR             0
 #define SUPPORT_NONLINEAR_EXTRUSION  0
 
-
-
 #define SUPPORT_INKJET		0					// set nonzero to support inkjet control
 #define SUPPORT_ROLAND		0					// set nonzero to support Roland mill
 #define SUPPORT_SCANNER		0					// set nonzero to support FreeLSS scanners
 #define SUPPORT_IOBITS		0					// set to support P parameter in G0/G1 commands
 #define SUPPORT_DHT_SENSOR	0					// set nonzero to support DHT temperature/humidity sensors
 
-
 #define ENABLE_TELNET 0
 #define ENABLE_FTP    0
-#define NO_PANELDUE                  1
+#define NO_PANELDUE   1
 
-//LCD Support with No Networking 
-#if defined(LPC_NETWORKING) || defined(ESP_NETWORKING)
-    #define SUPPORT_12864_LCD       0
-#else
-    #define SUPPORT_12864_LCD       1
-#endif
+#define SUPPORT_12864_LCD       1
 
 constexpr size_t NumExtraHeaterProtections = 4;
 constexpr size_t NumTachos = 0;
 constexpr Pin TachoPins[NumTachos] = {  };
 
-
 // The physical capabilities of the machine
-
 
 #if defined(__AZTEEGX5MINI__)
 # include "variants/AzteegX5Mini1_1.h"
@@ -72,6 +58,8 @@ constexpr Pin TachoPins[NumTachos] = {  };
 # include "variants/AZSMZ.h"
 #elif defined(__MKSSBASE__)
 # include "variants/MksSbase.h"
+#elif defined(__BIQUSKR__)
+# include "variants/BIQUSKR.h"
 #elif defined(__MBED__)
 //Only used for debugging
 # include "variants/MBed.h"

--- a/src/LPC/variants/AZSMZ.h
+++ b/src/LPC/variants/AZSMZ.h
@@ -188,10 +188,10 @@ constexpr SSPChannel LcdSpiChannel = SSP0;     //SSP0 (MISO0, MOSI0, SCK0)
 constexpr Pin LcdCSPin =       P1_22; //LCD Chip Select
 constexpr Pin LcdDCPin =       P2_6;  //DataControl Pin (A0) if none used set to NoPin
 constexpr Pin LcdBeepPin =     P1_30;
-constexpr Pin EncoderPinA =    P1_25;
+constexpr Pin EncoderPinA =    P4_28;
 constexpr Pin EncoderPinB =    P1_27;
 constexpr Pin EncoderPinSw =   P3_26; //click
-constexpr Pin PanelButtonPin = P1_22; //Extra button on Viki and RRD Panels (reset/back etc configurable)
+constexpr Pin PanelButtonPin = NoPin; //Extra button on Viki and RRD Panels (reset/back etc configurable)
 
 
 //VIKI2.0 Specific options

--- a/src/LPC/variants/MBed.h
+++ b/src/LPC/variants/MBed.h
@@ -19,7 +19,7 @@
 #define LPC_BOARD_STRING "MBED"
 
 //Firmware for networking version only. Non-networking firmware will need to be manually copied to Sdcard
-#define FIRMWARE_FILE "firmware-MBED-NETWORK.bin"
+#define FIRMWARE_FILE "firmware.bin"
 
 #define MBED
 

--- a/src/LPC/variants/MksSbase.h
+++ b/src/LPC/variants/MksSbase.h
@@ -20,8 +20,7 @@
 
 
 //Firmware for networking version only. Non-networking firmware will need to be manually copied to Sdcard
-#define FIRMWARE_FILE "firmware-MKSSBASE-NETWORK.bin"
-
+#define FIRMWARE_FILE "firmware.bin"
 
 #define MKSSBASE
 
@@ -87,7 +86,7 @@ constexpr Pin END_STOP_PINS[NumEndstops] = {P1_24, P1_26, P1_28, P1_25, P1_27, P
 // pins even a non-Arduino pin.
 
 //Note: default to NoPin for Probe.
-constexpr Pin Z_PROBE_PIN =       NoPin;
+constexpr Pin Z_PROBE_PIN =       P1_28;
 // Digital pin number to turn the IR LED on (high) or off (low)
 constexpr Pin Z_PROBE_MOD_PIN06 = NoPin;                                        // Digital pin number to turn the IR LED on (high) or off (low) on Duet v0.6 and v1.0 (PB21)
 constexpr Pin Z_PROBE_MOD_PIN07 = NoPin;                                        // Digital pin number to turn the IR LED on (high) or off (low) on Duet v0.7 and v0.8.5 (PC10)
@@ -112,7 +111,8 @@ constexpr float digipotFactor = 113.33; //factor for converting current to digip
 // Analogue pin numbers
 //                                                      Bed    H0     H1
 constexpr Pin TEMP_SENSE_PINS[NumThermistorInputs] = {P0_23, P0_24, P0_25};
-constexpr Pin HEAT_ON_PINS[NumHeaters] = {P2_5, P2_7, P2_6}; // bed, h0, h1
+constexpr Pin HEAT_ON_PINS[NumHeaters] = {P2_5, P2_7, P2_6}; // bed, h0, h1 // pin P2_6 is shared with fan 1
+
 
 // PWM -
 //       The Hardware PWM channels ALL share the same Frequency,
@@ -145,7 +145,7 @@ constexpr Pin HEAT_ON_PINS[NumHeaters] = {P2_5, P2_7, P2_6}; // bed, h0, h1
 #define Timer3_PWM_Frequency 250 //For Hotends not on HW PWM
 
 #define Timer1_PWMPins {P2_5, NoPin, NoPin } //Bed at 10Hz
-#define Timer2_PWMPins {NoPin, NoPin , NoPin}
+#define Timer2_PWMPins {P1_23, NoPin , NoPin}
 #define Timer3_PWMPins {P2_7, P2_6, NoPin}  //H0 and H1 at 250Hz
 
 
@@ -174,8 +174,8 @@ constexpr Pin DiagPin = NoPin;
 
 
 // Use a PWM capable pin
-constexpr size_t NUM_FANS = 1;
-constexpr Pin COOLING_FAN_PINS[NUM_FANS] = { P2_4 };
+constexpr size_t NUM_FANS = 2;
+constexpr Pin COOLING_FAN_PINS[NUM_FANS] = { P2_4, P2_6 }; // pin P2_6 is shared with heater h1
 
 //Pins defined to use for external interrupt. **Must** be a pin on Port0 or Port2.
 //I.e. for Fan RPM, Filament Detection etc
@@ -213,7 +213,8 @@ constexpr Pin SdSpiCSPins[NumSdCards] = { P0_6, P0_28 };// Internal, external. N
 
 constexpr Pin SpecialPinMap[] =
 {
-    P0_26   // TH4
+    P0_26,  // TH4
+    P1_23   // Servo 1
 };
 
 
@@ -221,7 +222,7 @@ constexpr Pin SpecialPinMap[] =
 //SPI LCD Common Settings (RRD Full Graphic Smart Display)
 constexpr SSPChannel LcdSpiChannel = SSP0;     //SSP0 (MISO0, MOSI0, SCK0)
 constexpr Pin LcdCSPin =       P0_16; //LCD Chip Select
-constexpr Pin LcdDCPin =       NoPin;  //DataControl Pin (A0) if none used set to NoPin
+constexpr Pin LcdDCPin =       P0_18;  //DataControl Pin (A0) if none used set to NoPin
 constexpr Pin LcdBeepPin =     P1_31;
 constexpr Pin EncoderPinA =    P3_25;
 constexpr Pin EncoderPinB =    P3_26;

--- a/src/LPC/variants/ReArm1_0.h
+++ b/src/LPC/variants/ReArm1_0.h
@@ -20,7 +20,7 @@
 #define LPC_BOARD_STRING "REARM"
 
 //Firmware for networking version only. Non-networking firmware will need to be manually copied to Sdcard
-#define FIRMWARE_FILE "firmware-REARM-NETWORK.bin"
+#define FIRMWARE_FILE "firmware.bin"
 
 
 

--- a/src/LPC/variants/Smoothieboard1.h
+++ b/src/LPC/variants/Smoothieboard1.h
@@ -19,7 +19,7 @@
 #define LPC_BOARD_STRING "SMOOTHIEBOARD"
 
 //Firmware for networking version only. Non-networking firmware will need to be manually copied to Sdcard
-#define FIRMWARE_FILE "firmware-SMOOTHIEBOARD-NETWORK.bin"
+#define FIRMWARE_FILE "firmware.bin"
 
 
 #define SMOOTHIEBOARD1


### PR DESCRIPTION
- Add support for the BIQU SKR V1.1.
- Add add servo support for the MKS SBASE.
- Add support for using heater 2 on the MKS SBASE as fan 1.
- Change the FIRMWARE_FILE definition to "firmware.bin" for LPC platforms to match the convention of other firmware like Smoothieware and Marlin.  As the makefile already defaults to this you don't need to rename when updating via the web interface.